### PR TITLE
Fix heartbeat command injection

### DIFF
--- a/dist/kernel.js
+++ b/dist/kernel.js
@@ -2,13 +2,12 @@ import fs from "node:fs/promises";
 import { watch } from "node:fs";
 import path from "node:path";
 import os from "node:os";
-import { exec, execFile } from "node:child_process";
+import { exec, spawn } from "node:child_process";
 import { promisify } from "node:util";
 import { fileURLToPath } from "node:url";
 import { parseFrontmatter, parseMarkdownSections, hashString, atomicWrite, nowIso, today, safeRead, safeReadJson, safeWrite, safeAppend, daysSince, hoursSince, fileExists } from "./utils.js";
 import { analyzePatterns, triggerEvolution as runEvolution } from "./evolution.js";
 const execAsync = promisify(exec);
-const execFileAsync = promisify(execFile);
 // === Configuration & Constants ===
 const HOME_DIR = os.homedir();
 export const MINICLAW_DIR = path.join(HOME_DIR, ".miniclaw");
@@ -28,6 +27,71 @@ const SKELETON_THRESHOLD = 300; // Lower threshold to trigger skeletonization ev
 function getSkillMeta(fm, key) {
     const meta = fm['metadata'];
     return meta?.[key] ?? fm[key];
+}
+export function stripPulseRouteTag(prompt) {
+    return prompt.replace(/^\[@[\w-]+\]\s*/, '');
+}
+export function getCognitivePulseCandidates(prompt) {
+    const candidates = [
+        { name: "ollama", args: ["run", "llama3"], promptDelivery: "argument" }, // High priority: Local & Free
+        { name: "ccr", args: ["code"], promptDelivery: "stdin" },
+        { name: "gemini", args: ["-p"], promptDelivery: "argument" },
+        { name: "qodercli", args: ["-p"], promptDelivery: "argument" },
+        { name: "opencode", args: [], promptDelivery: "argument" },
+        { name: "codex", args: [], promptDelivery: "argument" },
+        { name: "claude", args: ["-p", "--output-format", "text"], promptDelivery: "argument" },
+        { name: "aider", args: ["--message"], promptDelivery: "argument" },
+        { name: "fabric", args: ["-p", "extract_wisdom"], promptDelivery: "argument" },
+        { name: "gh", args: ["copilot", "explain"], promptDelivery: "argument" },
+        { name: "interpreter", args: ["--brief", "-y"], promptDelivery: "argument" },
+    ];
+    const routeMatch = prompt.match(/^\[@([\w-]+)\]/);
+    if (!routeMatch)
+        return candidates;
+    const targetName = routeMatch[1];
+    const idx = candidates.findIndex(c => c.name === targetName);
+    if (idx === -1)
+        return candidates;
+    const [target] = candidates.splice(idx, 1);
+    candidates.unshift(target);
+    return candidates;
+}
+function executeProcess(command, args, stdin, env) {
+    return new Promise((resolve, reject) => {
+        const child = spawn(command, args, {
+            cwd: process.cwd(),
+            env,
+            shell: false,
+            stdio: ["pipe", "pipe", "pipe"],
+        });
+        let stdout = "";
+        let stderr = "";
+        child.stdout.setEncoding("utf-8");
+        child.stderr.setEncoding("utf-8");
+        child.stdout.on("data", chunk => { stdout += chunk; });
+        child.stderr.on("data", chunk => { stderr += chunk; });
+        child.stdin.on("error", () => { });
+        child.on("error", reject);
+        child.on("close", (code, signal) => {
+            if (code === 0) {
+                resolve({ stdout, stderr });
+                return;
+            }
+            const detail = signal ? `signal ${signal}` : `exit code ${code}`;
+            const err = new Error(`Command failed (${detail}): ${command}`);
+            Object.assign(err, { stdout, stderr, code });
+            reject(err);
+        });
+        child.stdin.end(stdin);
+    });
+}
+export async function runCognitivePulseCandidate(candidate, prompt, env = process.env) {
+    const finalPrompt = stripPulseRouteTag(prompt);
+    const args = candidate.promptDelivery === "argument"
+        ? [...candidate.args, finalPrompt]
+        : candidate.args;
+    const stdin = candidate.promptDelivery === "stdin" ? finalPrompt : "";
+    return executeProcess(candidate.name, args, stdin, env);
 }
 // === Helper: Safe file stat with null handling ===
 async function safeStat(filePath) {
@@ -403,30 +467,10 @@ export class ContextKernel {
             if (!content || content.trim().length === 0)
                 return;
             const prompt = content.trim();
-            const candidates = [
-                { name: "ollama", args: "run llama3" }, // High priority: Local & Free
-                { name: "ccr", args: "code" },
-                { name: "gemini", args: "-p" },
-                { name: "qodercli", args: "-p" },
-                { name: "opencode", args: "" },
-                { name: "codex", args: "" },
-                { name: "claude", args: "-p --output-format text" },
-                { name: "aider", args: "--message" },
-                { name: "fabric", args: "-p extract_wisdom" },
-                { name: "gh", args: "copilot explain" },
-                { name: "interpreter", args: "--brief -y" }
-            ];
-            // --- Smart Routing ---
-            // If the prompt starts with [@name], move that candidate to the top
+            const candidates = getCognitivePulseCandidates(prompt);
             const routeMatch = prompt.match(/^\[@([\w-]+)\]/);
-            if (routeMatch) {
-                const targetName = routeMatch[1];
-                const idx = candidates.findIndex(c => c.name === targetName);
-                if (idx !== -1) {
-                    const [target] = candidates.splice(idx, 1);
-                    candidates.unshift(target);
-                    console.error(`[MiniClaw] Smart Routing: Prioritizing ${targetName} per prompt tag.`);
-                }
+            if (routeMatch && candidates[0]?.name === routeMatch[1]) {
+                console.error(`[MiniClaw] Smart Routing: Prioritizing ${routeMatch[1]} per prompt tag.`);
             }
             let success = false;
             let lastError = "";
@@ -435,19 +479,7 @@ export class ContextKernel {
                 try {
                     // 2. Attempt execution
                     console.error(`[MiniClaw] Cognitive Pulse: Attempting via ${cli.name}...`);
-                    const finalPrompt = prompt.replace(/^\[@[\w-]+\]\s*/, '');
-                    // Use echo piping to ensure prompt is delivered to stdin if needed
-                    // and use -n to avoid newline issues where appropriate.
-                    // ccr code often expects the prompt either as arg or stdin.
-                    let finalCmd = `${cli.name} ${cli.args} "${finalPrompt.replace(/"/g, '\\"')}"`;
-                    if (cli.name === 'ccr') {
-                        // For Claude Code Router, sometimes it prefers the prompt via pipe
-                        finalCmd = `echo "${finalPrompt.replace(/"/g, '\\"')}" | ccr code`;
-                    }
-                    else {
-                        finalCmd = `${finalCmd} < /dev/null`;
-                    }
-                    const { stdout, stderr } = await execAsync(finalCmd, { env });
+                    const { stdout, stderr } = await runCognitivePulseCandidate(cli, prompt, env);
                     // 3. Log success
                     await this.logActivity(`Cognitive Pulse Success via ${cli.name}`);
                     const timestamp = `[${nowIso()}]`;

--- a/src/kernel.ts
+++ b/src/kernel.ts
@@ -3,14 +3,13 @@ import fs from "node:fs/promises";
 import { watch } from "node:fs";
 import path from "node:path";
 import os from "node:os";
-import { exec, execFile } from "node:child_process";
+import { exec, spawn } from "node:child_process";
 import { promisify } from "node:util";
 import { fileURLToPath } from "node:url";
 import { parseFrontmatter, parseMarkdownSections, hashString, atomicWrite, blend, clamp, nowIso, today, safeRead, safeReadJson, safeWrite, safeAppend, daysSince, hoursSince, fileExists } from "./utils.js";
 import { analyzePatterns, triggerEvolution as runEvolution } from "./evolution.js";
 
 const execAsync = promisify(exec);
-const execFileAsync = promisify(execFile);
 
 // === Configuration & Constants ===
 const HOME_DIR = os.homedir();
@@ -81,6 +80,94 @@ interface SkillCacheEntry {
 function getSkillMeta(fm: Record<string, unknown>, key: string): unknown {
     const meta = fm['metadata'] as Record<string, unknown> | undefined;
     return meta?.[key] ?? fm[key];
+}
+
+export interface CognitivePulseCandidate {
+    name: string;
+    args: string[];
+    promptDelivery: "argument" | "stdin";
+}
+
+interface ProcessOutput {
+    stdout: string;
+    stderr: string;
+}
+
+export function stripPulseRouteTag(prompt: string): string {
+    return prompt.replace(/^\[@[\w-]+\]\s*/, '');
+}
+
+export function getCognitivePulseCandidates(prompt: string): CognitivePulseCandidate[] {
+    const candidates: CognitivePulseCandidate[] = [
+        { name: "ollama", args: ["run", "llama3"], promptDelivery: "argument" }, // High priority: Local & Free
+        { name: "ccr", args: ["code"], promptDelivery: "stdin" },
+        { name: "gemini", args: ["-p"], promptDelivery: "argument" },
+        { name: "qodercli", args: ["-p"], promptDelivery: "argument" },
+        { name: "opencode", args: [], promptDelivery: "argument" },
+        { name: "codex", args: [], promptDelivery: "argument" },
+        { name: "claude", args: ["-p", "--output-format", "text"], promptDelivery: "argument" },
+        { name: "aider", args: ["--message"], promptDelivery: "argument" },
+        { name: "fabric", args: ["-p", "extract_wisdom"], promptDelivery: "argument" },
+        { name: "gh", args: ["copilot", "explain"], promptDelivery: "argument" },
+        { name: "interpreter", args: ["--brief", "-y"], promptDelivery: "argument" },
+    ];
+
+    const routeMatch = prompt.match(/^\[@([\w-]+)\]/);
+    if (!routeMatch) return candidates;
+
+    const targetName = routeMatch[1];
+    const idx = candidates.findIndex(c => c.name === targetName);
+    if (idx === -1) return candidates;
+
+    const [target] = candidates.splice(idx, 1);
+    candidates.unshift(target);
+    return candidates;
+}
+
+function executeProcess(command: string, args: string[], stdin: string, env: NodeJS.ProcessEnv): Promise<ProcessOutput> {
+    return new Promise((resolve, reject) => {
+        const child = spawn(command, args, {
+            cwd: process.cwd(),
+            env,
+            shell: false,
+            stdio: ["pipe", "pipe", "pipe"],
+        });
+
+        let stdout = "";
+        let stderr = "";
+
+        child.stdout.setEncoding("utf-8");
+        child.stderr.setEncoding("utf-8");
+        child.stdout.on("data", chunk => { stdout += chunk; });
+        child.stderr.on("data", chunk => { stderr += chunk; });
+        child.stdin.on("error", () => { });
+        child.on("error", reject);
+        child.on("close", (code, signal) => {
+            if (code === 0) {
+                resolve({ stdout, stderr });
+                return;
+            }
+            const detail = signal ? `signal ${signal}` : `exit code ${code}`;
+            const err = new Error(`Command failed (${detail}): ${command}`);
+            Object.assign(err, { stdout, stderr, code });
+            reject(err);
+        });
+
+        child.stdin.end(stdin);
+    });
+}
+
+export async function runCognitivePulseCandidate(
+    candidate: CognitivePulseCandidate,
+    prompt: string,
+    env: NodeJS.ProcessEnv = process.env
+): Promise<ProcessOutput> {
+    const finalPrompt = stripPulseRouteTag(prompt);
+    const args = candidate.promptDelivery === "argument"
+        ? [...candidate.args, finalPrompt]
+        : candidate.args;
+    const stdin = candidate.promptDelivery === "stdin" ? finalPrompt : "";
+    return executeProcess(candidate.name, args, stdin, env);
 }
 
 // === Content Hash State ===
@@ -554,31 +641,10 @@ export class ContextKernel {
             if (!content || content.trim().length === 0) return;
 
             const prompt = content.trim();
-            const candidates = [
-                { name: "ollama", args: "run llama3" }, // High priority: Local & Free
-                { name: "ccr", args: "code" },
-                { name: "gemini", args: "-p" },
-                { name: "qodercli", args: "-p" },
-                { name: "opencode", args: "" },
-                { name: "codex", args: "" },
-                { name: "claude", args: "-p --output-format text" },
-                { name: "aider", args: "--message" },
-                { name: "fabric", args: "-p extract_wisdom" },
-                { name: "gh", args: "copilot explain" },
-                { name: "interpreter", args: "--brief -y" }
-            ];
-
-            // --- Smart Routing ---
-            // If the prompt starts with [@name], move that candidate to the top
+            const candidates = getCognitivePulseCandidates(prompt);
             const routeMatch = prompt.match(/^\[@([\w-]+)\]/);
-            if (routeMatch) {
-                const targetName = routeMatch[1];
-                const idx = candidates.findIndex(c => c.name === targetName);
-                if (idx !== -1) {
-                    const [target] = candidates.splice(idx, 1);
-                    candidates.unshift(target);
-                    console.error(`[MiniClaw] Smart Routing: Prioritizing ${targetName} per prompt tag.`);
-                }
+            if (routeMatch && candidates[0]?.name === routeMatch[1]) {
+                console.error(`[MiniClaw] Smart Routing: Prioritizing ${routeMatch[1]} per prompt tag.`);
             }
 
             let success = false;
@@ -589,20 +655,7 @@ export class ContextKernel {
                 try {
                     // 2. Attempt execution
                     console.error(`[MiniClaw] Cognitive Pulse: Attempting via ${cli.name}...`);
-                    const finalPrompt = prompt.replace(/^\[@[\w-]+\]\s*/, '');
-                    
-                    // Use echo piping to ensure prompt is delivered to stdin if needed
-                    // and use -n to avoid newline issues where appropriate.
-                    // ccr code often expects the prompt either as arg or stdin.
-                    let finalCmd = `${cli.name} ${cli.args} "${finalPrompt.replace(/"/g, '\\"')}"`;
-                    if (cli.name === 'ccr') {
-                        // For Claude Code Router, sometimes it prefers the prompt via pipe
-                        finalCmd = `echo "${finalPrompt.replace(/"/g, '\\"')}" | ccr code`;
-                    } else {
-                        finalCmd = `${finalCmd} < /dev/null`;
-                    }
-
-                    const { stdout, stderr } = await execAsync(finalCmd, { env });
+                    const { stdout, stderr } = await runCognitivePulseCandidate(cli, prompt, env);
                     
                     // 3. Log success
                     await this.logActivity(`Cognitive Pulse Success via ${cli.name}`);

--- a/tests/kernel.test.ts
+++ b/tests/kernel.test.ts
@@ -1,0 +1,88 @@
+import { access, chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+    getCognitivePulseCandidates,
+    runCognitivePulseCandidate,
+    stripPulseRouteTag,
+    type CognitivePulseCandidate,
+} from "../src/kernel.js";
+
+const tempDirs: string[] = [];
+
+async function exists(filePath: string): Promise<boolean> {
+    return access(filePath).then(() => true, () => false);
+}
+
+async function makeFakeCli(): Promise<{ dir: string; argvFile: string; stdinFile: string }> {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "miniclaw-test-"));
+    tempDirs.push(dir);
+    const argvFile = path.join(dir, "argv.txt");
+    const stdinFile = path.join(dir, "stdin.txt");
+    const cliPath = path.join(dir, "fakecli");
+    await writeFile(cliPath, [
+        "#!/bin/sh",
+        "printf '%s\\n' \"$@\" > \"$MINICLAW_TEST_ARGV\"",
+        "cat > \"$MINICLAW_TEST_STDIN\"",
+        "printf 'ok\\n'",
+        "",
+    ].join("\n"));
+    await chmod(cliPath, 0o755);
+    return { dir, argvFile, stdinFile };
+}
+
+afterEach(async () => {
+    await Promise.all(tempDirs.splice(0).map(dir => rm(dir, { recursive: true, force: true })));
+});
+
+describe("Cognitive pulse command execution", () => {
+    it("keeps route tags out of the prompt text sent to CLIs", () => {
+        expect(stripPulseRouteTag("[@ollama] review this")).toBe("review this");
+        expect(getCognitivePulseCandidates("[@claude] review this")[0].name).toBe("claude");
+    });
+
+    it("passes heartbeat prompt as argv without shell expansion", async () => {
+        const { dir, argvFile, stdinFile } = await makeFakeCli();
+        const marker = path.join(dir, "shell-expanded");
+        const prompt = `Test payload $(touch ${marker})`;
+        const candidate: CognitivePulseCandidate = {
+            name: "fakecli",
+            args: ["--message"],
+            promptDelivery: "argument",
+        };
+
+        await runCognitivePulseCandidate(candidate, prompt, {
+            ...process.env,
+            PATH: `${dir}:${process.env.PATH || ""}`,
+            MINICLAW_TEST_ARGV: argvFile,
+            MINICLAW_TEST_STDIN: stdinFile,
+        });
+
+        expect(await exists(marker)).toBe(false);
+        expect(await readFile(argvFile, "utf-8")).toContain(prompt);
+        expect(await readFile(stdinFile, "utf-8")).toBe("");
+    });
+
+    it("passes ccr-style heartbeat prompt through stdin without shell expansion", async () => {
+        const { dir, argvFile, stdinFile } = await makeFakeCli();
+        const marker = path.join(dir, "stdin-shell-expanded");
+        const prompt = `Inject $(touch ${marker})`;
+        const candidate: CognitivePulseCandidate = {
+            name: "fakecli",
+            args: ["code"],
+            promptDelivery: "stdin",
+        };
+
+        await runCognitivePulseCandidate(candidate, prompt, {
+            ...process.env,
+            PATH: `${dir}:${process.env.PATH || ""}`,
+            MINICLAW_TEST_ARGV: argvFile,
+            MINICLAW_TEST_STDIN: stdinFile,
+        });
+
+        expect(await exists(marker)).toBe(false);
+        expect(await readFile(argvFile, "utf-8")).toBe("code\n");
+        expect(await readFile(stdinFile, "utf-8")).toBe(prompt);
+    });
+});


### PR DESCRIPTION
## Summary
- Replace shell-built heartbeat CLI commands with spawn(..., shell: false) and argument/stdin delivery.
- Keep smart routing behavior while removing shell interpolation of HEARTBEAT.md content.
- Add regression tests for $(...) payloads passed as argv and stdin.

Fixes #4.

## Verification
- npm test
- npm run build