### PR TITLE
Fix skill script path traversal

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -5,7 +5,7 @@ import { CallToolRequestSchema, ListResourcesRequestSchema, ListToolsRequestSche
 import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { ContextKernel, MINICLAW_DIR } from "./kernel.js";
+import { ContextKernel, MINICLAW_DIR, resolveSkillDirPath } from "./kernel.js";
 import { textResult, errorResult, today, nowIso, fileExists, safeRead, safeReadJson, safeAppend, hashString, parseMarkdownSections } from "./utils.js";
 // Configuration
 const kernel = new ContextKernel();
@@ -462,7 +462,7 @@ const HANDLERS = {
         if (action === "create") {
             if (!name || !description || !content)
                 throw new Error("name/desc/content required");
-            const sdir = path.join(dir, name);
+            const sdir = resolveSkillDirPath(name, dir);
             await fs.mkdir(sdir, { recursive: true });
             let ex = exec ? `exec: "${exec.split(' ')[0]} ${path.join(sdir, exec.split(' ').slice(1).join(' '))}"\n` : '';
             await fs.writeFile(path.join(sdir, "SKILL.md"), `---\nname: ${name}\ndescription: ${description}\n${ex}---\n\n${content}`);
@@ -471,7 +471,7 @@ const HANDLERS = {
             return textResult(`✅ Skill **${name}** created.`);
         }
         if (action === "delete")
-            return fs.rm(path.join(dir, name), { recursive: true }).then(() => textResult(`Deleted ${name}`));
+            return fs.rm(resolveSkillDirPath(name, dir), { recursive: true }).then(() => textResult(`Deleted ${name}`));
         return errorResult("Unknown action");
     }
 };

--- a/dist/kernel.js
+++ b/dist/kernel.js
@@ -29,6 +29,27 @@ function getSkillMeta(fm, key) {
     const meta = fm['metadata'];
     return meta?.[key] ?? fm[key];
 }
+function isPathInside(basePath, targetPath) {
+    const relative = path.relative(basePath, targetPath);
+    return relative === "" || (!!relative && !relative.startsWith("..") && !path.isAbsolute(relative));
+}
+export function resolveSkillDirPath(skillName, skillsDir = SKILLS_DIR) {
+    const skillsRoot = path.resolve(skillsDir);
+    const skillDir = path.resolve(skillsRoot, skillName);
+    const relative = path.relative(skillsRoot, skillDir);
+    if (!relative || relative.startsWith("..") || path.isAbsolute(relative)) {
+        throw new Error("Security violation: skill path escapes skills directory");
+    }
+    return skillDir;
+}
+export function resolveSkillScriptPath(skillName, scriptFile, skillsDir = SKILLS_DIR) {
+    const skillDir = resolveSkillDirPath(skillName, skillsDir);
+    const scriptPath = path.resolve(skillDir, scriptFile);
+    if (!isPathInside(skillDir, scriptPath)) {
+        throw new Error("Security violation: script path escapes skill directory");
+    }
+    return { skillDir, scriptPath };
+}
 // === Helper: Safe file stat with null handling ===
 async function safeStat(filePath) {
     try {
@@ -939,7 +960,14 @@ export class ContextKernel {
     }
     // === EXEC: Executable Skills ===
     async executeSkillScript(skillName, scriptFile, args = {}) {
-        const scriptPath = path.join(SKILLS_DIR, skillName, scriptFile);
+        let skillDir;
+        let scriptPath;
+        try {
+            ({ skillDir, scriptPath } = resolveSkillScriptPath(skillName, scriptFile));
+        }
+        catch (e) {
+            return e instanceof Error ? e.message : "Security violation";
+        }
         // 1. Ensure file exists
         try {
             await fs.access(scriptPath);
@@ -947,30 +975,43 @@ export class ContextKernel {
         catch {
             return `Error: Script '${scriptFile}' not found.`;
         }
+        let realSkillDir;
+        let realScriptPath;
+        try {
+            [realSkillDir, realScriptPath] = await Promise.all([
+                fs.realpath(skillDir),
+                fs.realpath(scriptPath),
+            ]);
+            if (!isPathInside(realSkillDir, realScriptPath)) {
+                return "Security violation: script path escapes skill directory";
+            }
+        }
+        catch {
+            return `Error: Script '${scriptFile}' not found.`;
+        }
         // 2. Prepare execution
-        let cmd = scriptPath;
-        if (scriptPath.endsWith('.js')) {
-            cmd = `node "${scriptPath}"`;
+        let executable = realScriptPath;
+        let execArgs = [];
+        if (realScriptPath.endsWith('.js')) {
+            executable = process.execPath;
+            execArgs = [realScriptPath];
         }
         else {
             // Try making it executable
             try {
-                await fs.chmod(scriptPath, '755');
+                await fs.chmod(realScriptPath, '755');
             }
             catch (e) {
                 console.error(`[MiniClaw] Failed to chmod script: ${e}`);
             }
-            cmd = `"${scriptPath}"`;
         }
-        // Pass arguments as a serialized JSON string to avoiding escaping mayhem
+        // Pass arguments as a serialized JSON string to avoid shell escaping.
         const argsStr = JSON.stringify(args);
-        // Be careful with quoting args string for bash
-        const safeArgs = argsStr.replace(/'/g, "'\\''");
-        const fullCmd = `${cmd} '${safeArgs}'`;
+        execArgs.push(argsStr);
         // 3. Execute
         try {
-            const { stdout, stderr } = await execAsync(fullCmd, {
-                cwd: path.join(SKILLS_DIR, skillName),
+            const { stdout, stderr } = await execFileAsync(executable, execArgs, {
+                cwd: realSkillDir,
                 timeout: 30000,
                 maxBuffer: 1024 * 1024
             });
@@ -982,10 +1023,11 @@ export class ContextKernel {
     }
     // === SANDBOX VALIDATION ===
     async validateSkillSandbox(skillName, validationCmd) {
-        const skillDir = path.join(SKILLS_DIR, skillName);
+        const skillDir = resolveSkillDirPath(skillName);
         try {
             // Run in a restricted environment with a strict timeout
-            const { stdout, stderr } = await execAsync(`cd "${skillDir}" && ${validationCmd}`, {
+            const { stdout, stderr } = await execAsync(validationCmd, {
+                cwd: skillDir,
                 timeout: 2000, // 2 seconds P0 strict timeout for generated skills
                 env: { ...process.env, MINICLAW_SANDBOX: "1" }
             });
@@ -1384,7 +1426,8 @@ export class ContextKernel {
             return skill?.content || "";
         }
         try {
-            return await fs.readFile(path.join(SKILLS_DIR, skillName, fileName), "utf-8");
+            const { scriptPath } = resolveSkillScriptPath(skillName, fileName);
+            return await fs.readFile(scriptPath, "utf-8");
         }
         catch {
             return "";

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ import {
 import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { ContextKernel, MINICLAW_DIR } from "./kernel.js";
+import { ContextKernel, MINICLAW_DIR, resolveSkillDirPath } from "./kernel.js";
 import { textResult, errorResult, today, nowIso, fileExists, safeRead, safeReadJson, safeAppend, hashString, parseMarkdownSections } from "./utils.js";
 
 // Configuration
@@ -510,14 +510,14 @@ const HANDLERS: Record<string, (args: any) => Promise<any>> = {
         }
         if (action === "create") {
             if (!name || !description || !content) throw new Error("name/desc/content required");
-            const sdir = path.join(dir, name);
+            const sdir = resolveSkillDirPath(name, dir);
             await fs.mkdir(sdir, { recursive: true });
             let ex = exec ? `exec: "${exec.split(' ')[0]} ${path.join(sdir, exec.split(' ').slice(1).join(' '))}"\n` : '';
             await fs.writeFile(path.join(sdir, "SKILL.md"), `---\nname: ${name}\ndescription: ${description}\n${ex}---\n\n${content}`);
             if (validationCmd) await kernel.validateSkillSandbox(name, validationCmd).catch(async e => { await fs.rm(sdir, { recursive: true }); throw e; });
             return textResult(`✅ Skill **${name}** created.`);
         }
-        if (action === "delete") return fs.rm(path.join(dir, name), { recursive: true }).then(() => textResult(`Deleted ${name}`));
+        if (action === "delete") return fs.rm(resolveSkillDirPath(name, dir), { recursive: true }).then(() => textResult(`Deleted ${name}`));
         return errorResult("Unknown action");
     }
 };

--- a/src/kernel.ts
+++ b/src/kernel.ts
@@ -83,6 +83,35 @@ function getSkillMeta(fm: Record<string, unknown>, key: string): unknown {
     return meta?.[key] ?? fm[key];
 }
 
+function isPathInside(basePath: string, targetPath: string): boolean {
+    const relative = path.relative(basePath, targetPath);
+    return relative === "" || (!!relative && !relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+export function resolveSkillDirPath(skillName: string, skillsDir = SKILLS_DIR): string {
+    const skillsRoot = path.resolve(skillsDir);
+    const skillDir = path.resolve(skillsRoot, skillName);
+    const relative = path.relative(skillsRoot, skillDir);
+    if (!relative || relative.startsWith("..") || path.isAbsolute(relative)) {
+        throw new Error("Security violation: skill path escapes skills directory");
+    }
+    return skillDir;
+}
+
+export function resolveSkillScriptPath(
+    skillName: string,
+    scriptFile: string,
+    skillsDir = SKILLS_DIR
+): { skillDir: string; scriptPath: string } {
+    const skillDir = resolveSkillDirPath(skillName, skillsDir);
+    const scriptPath = path.resolve(skillDir, scriptFile);
+    if (!isPathInside(skillDir, scriptPath)) {
+        throw new Error("Security violation: script path escapes skill directory");
+    }
+
+    return { skillDir, scriptPath };
+}
+
 // === Content Hash State ===
 export interface ContentHashes {
     [sectionName: string]: string;
@@ -1132,7 +1161,13 @@ export class ContextKernel {
     // === EXEC: Executable Skills ===
 
     async executeSkillScript(skillName: string, scriptFile: string, args: Record<string, unknown> = {}): Promise<string> {
-        const scriptPath = path.join(SKILLS_DIR, skillName, scriptFile);
+        let skillDir: string;
+        let scriptPath: string;
+        try {
+            ({ skillDir, scriptPath } = resolveSkillScriptPath(skillName, scriptFile));
+        } catch (e) {
+            return e instanceof Error ? e.message : "Security violation";
+        }
 
         // 1. Ensure file exists
         try {
@@ -1141,26 +1176,39 @@ export class ContextKernel {
             return `Error: Script '${scriptFile}' not found.`;
         }
 
-        // 2. Prepare execution
-        let cmd = scriptPath;
-        if (scriptPath.endsWith('.js')) {
-            cmd = `node "${scriptPath}"`;
-        } else {
-            // Try making it executable
-            try { await fs.chmod(scriptPath, '755'); } catch (e) { console.error(`[MiniClaw] Failed to chmod script: ${e}`); }
-            cmd = `"${scriptPath}"`;
+        let realSkillDir: string;
+        let realScriptPath: string;
+        try {
+            [realSkillDir, realScriptPath] = await Promise.all([
+                fs.realpath(skillDir),
+                fs.realpath(scriptPath),
+            ]);
+            if (!isPathInside(realSkillDir, realScriptPath)) {
+                return "Security violation: script path escapes skill directory";
+            }
+        } catch {
+            return `Error: Script '${scriptFile}' not found.`;
         }
 
-        // Pass arguments as a serialized JSON string to avoiding escaping mayhem
+        // 2. Prepare execution
+        let executable = realScriptPath;
+        let execArgs: string[] = [];
+        if (realScriptPath.endsWith('.js')) {
+            executable = process.execPath;
+            execArgs = [realScriptPath];
+        } else {
+            // Try making it executable
+            try { await fs.chmod(realScriptPath, '755'); } catch (e) { console.error(`[MiniClaw] Failed to chmod script: ${e}`); }
+        }
+
+        // Pass arguments as a serialized JSON string to avoid shell escaping.
         const argsStr = JSON.stringify(args);
-        // Be careful with quoting args string for bash
-        const safeArgs = argsStr.replace(/'/g, "'\\''");
-        const fullCmd = `${cmd} '${safeArgs}'`;
+        execArgs.push(argsStr);
 
         // 3. Execute
         try {
-            const { stdout, stderr } = await execAsync(fullCmd, {
-                cwd: path.join(SKILLS_DIR, skillName),
+            const { stdout, stderr } = await execFileAsync(executable, execArgs, {
+                cwd: realSkillDir,
                 timeout: 30000,
                 maxBuffer: 1024 * 1024
             });
@@ -1172,11 +1220,12 @@ export class ContextKernel {
 
     // === SANDBOX VALIDATION ===
     async validateSkillSandbox(skillName: string, validationCmd: string): Promise<void> {
-        const skillDir = path.join(SKILLS_DIR, skillName);
+        const skillDir = resolveSkillDirPath(skillName);
 
         try {
             // Run in a restricted environment with a strict timeout
-            const { stdout, stderr } = await execAsync(`cd "${skillDir}" && ${validationCmd}`, {
+            const { stdout, stderr } = await execAsync(validationCmd, {
+                cwd: skillDir,
                 timeout: 2000, // 2 seconds P0 strict timeout for generated skills
                 env: { ...process.env, MINICLAW_SANDBOX: "1" }
             });
@@ -1597,7 +1646,10 @@ export class ContextKernel {
             const skill = skills.get(skillName);
             return skill?.content || "";
         }
-        try { return await fs.readFile(path.join(SKILLS_DIR, skillName, fileName), "utf-8"); }
+        try {
+            const { scriptPath } = resolveSkillScriptPath(skillName, fileName);
+            return await fs.readFile(scriptPath, "utf-8");
+        }
         catch { return ""; }
     }
 

--- a/tests/skill-path.test.ts
+++ b/tests/skill-path.test.ts
@@ -1,0 +1,41 @@
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { ContextKernel, resolveSkillDirPath, resolveSkillScriptPath } from "../src/kernel.js";
+
+describe("Skill script path resolution", () => {
+    it("allows scripts inside a skill directory", () => {
+        const skillsDir = path.join(os.tmpdir(), "miniclaw-skills");
+        const resolved = resolveSkillScriptPath("demo", "run.js", skillsDir);
+
+        expect(resolved.skillDir).toBe(path.join(skillsDir, "demo"));
+        expect(resolved.scriptPath).toBe(path.join(skillsDir, "demo", "run.js"));
+    });
+
+    it("rejects skillName traversal outside the skills directory", () => {
+        const skillsDir = path.join(os.tmpdir(), "miniclaw-skills");
+
+        expect(() => resolveSkillScriptPath("../../../../etc", "passwd", skillsDir))
+            .toThrow("Security violation");
+    });
+
+    it("rejects the skills root itself as a skill directory target", () => {
+        const skillsDir = path.join(os.tmpdir(), "miniclaw-skills");
+
+        expect(() => resolveSkillDirPath(".", skillsDir)).toThrow("Security violation");
+    });
+
+    it("rejects scriptFile traversal outside its skill directory", () => {
+        const skillsDir = path.join(os.tmpdir(), "miniclaw-skills");
+
+        expect(() => resolveSkillScriptPath("demo", "../other/run.js", skillsDir))
+            .toThrow("Security violation");
+    });
+
+    it("blocks the reported executeSkillScript traversal pattern before filesystem access", async () => {
+        const kernel = new ContextKernel();
+
+        await expect(kernel.executeSkillScript("../../../../etc", "passwd", {}))
+            .resolves.toContain("Security violation");
+    });
+});


### PR DESCRIPTION
## Summary
- Add skills-directory path guards for skill execution paths.
- Block skillName and scriptFile traversal before filesystem access.
- Reuse the guard for skill create/delete, skill content reads, and sandbox validation.
- Execute skill scripts with execFile instead of shell-built command strings.
- Add regression tests for the reported traversal pattern and related boundary cases.

Fixes #5.

## Verification
- npm test
- npm run build