### PR TITLE
Add regression test for skill arg injection

### DIFF
--- a/dist/kernel.js
+++ b/dist/kernel.js
@@ -50,6 +50,50 @@ export function resolveSkillScriptPath(skillName, scriptFile, skillsDir = SKILLS
     }
     return { skillDir, scriptPath };
 }
+export async function executeResolvedSkillScript(skillDir, scriptPath, args = {}) {
+    let realSkillDir;
+    let realScriptPath;
+    try {
+        [realSkillDir, realScriptPath] = await Promise.all([
+            fs.realpath(skillDir),
+            fs.realpath(scriptPath),
+        ]);
+        if (!isPathInside(realSkillDir, realScriptPath)) {
+            return "Security violation: script path escapes skill directory";
+        }
+    }
+    catch {
+        return `Error: Script '${path.basename(scriptPath)}' not found.`;
+    }
+    let executable = realScriptPath;
+    let execArgs = [];
+    if (realScriptPath.endsWith('.js')) {
+        executable = process.execPath;
+        execArgs = [realScriptPath];
+    }
+    else {
+        // Try making it executable
+        try {
+            await fs.chmod(realScriptPath, '755');
+        }
+        catch (e) {
+            console.error(`[MiniClaw] Failed to chmod script: ${e}`);
+        }
+    }
+    // Pass arguments as a serialized JSON string to avoid shell escaping.
+    execArgs.push(JSON.stringify(args));
+    try {
+        const { stdout, stderr } = await execFileAsync(executable, execArgs, {
+            cwd: realSkillDir,
+            timeout: 30000,
+            maxBuffer: 1024 * 1024
+        });
+        return stdout || stderr;
+    }
+    catch (e) {
+        return `Skill execution failed: ${e.message}\nOutput: ${e.stdout || e.stderr}`;
+    }
+}
 // === Helper: Safe file stat with null handling ===
 async function safeStat(filePath) {
     try {
@@ -975,51 +1019,7 @@ export class ContextKernel {
         catch {
             return `Error: Script '${scriptFile}' not found.`;
         }
-        let realSkillDir;
-        let realScriptPath;
-        try {
-            [realSkillDir, realScriptPath] = await Promise.all([
-                fs.realpath(skillDir),
-                fs.realpath(scriptPath),
-            ]);
-            if (!isPathInside(realSkillDir, realScriptPath)) {
-                return "Security violation: script path escapes skill directory";
-            }
-        }
-        catch {
-            return `Error: Script '${scriptFile}' not found.`;
-        }
-        // 2. Prepare execution
-        let executable = realScriptPath;
-        let execArgs = [];
-        if (realScriptPath.endsWith('.js')) {
-            executable = process.execPath;
-            execArgs = [realScriptPath];
-        }
-        else {
-            // Try making it executable
-            try {
-                await fs.chmod(realScriptPath, '755');
-            }
-            catch (e) {
-                console.error(`[MiniClaw] Failed to chmod script: ${e}`);
-            }
-        }
-        // Pass arguments as a serialized JSON string to avoid shell escaping.
-        const argsStr = JSON.stringify(args);
-        execArgs.push(argsStr);
-        // 3. Execute
-        try {
-            const { stdout, stderr } = await execFileAsync(executable, execArgs, {
-                cwd: realSkillDir,
-                timeout: 30000,
-                maxBuffer: 1024 * 1024
-            });
-            return stdout || stderr;
-        }
-        catch (e) {
-            return `Skill execution failed: ${e.message}\nOutput: ${e.stdout || e.stderr}`;
-        }
+        return executeResolvedSkillScript(skillDir, scriptPath, args);
     }
     // === SANDBOX VALIDATION ===
     async validateSkillSandbox(skillName, validationCmd) {

--- a/src/kernel.ts
+++ b/src/kernel.ts
@@ -112,6 +112,50 @@ export function resolveSkillScriptPath(
     return { skillDir, scriptPath };
 }
 
+export async function executeResolvedSkillScript(
+    skillDir: string,
+    scriptPath: string,
+    args: Record<string, unknown> = {}
+): Promise<string> {
+    let realSkillDir: string;
+    let realScriptPath: string;
+    try {
+        [realSkillDir, realScriptPath] = await Promise.all([
+            fs.realpath(skillDir),
+            fs.realpath(scriptPath),
+        ]);
+        if (!isPathInside(realSkillDir, realScriptPath)) {
+            return "Security violation: script path escapes skill directory";
+        }
+    } catch {
+        return `Error: Script '${path.basename(scriptPath)}' not found.`;
+    }
+
+    let executable = realScriptPath;
+    let execArgs: string[] = [];
+    if (realScriptPath.endsWith('.js')) {
+        executable = process.execPath;
+        execArgs = [realScriptPath];
+    } else {
+        // Try making it executable
+        try { await fs.chmod(realScriptPath, '755'); } catch (e) { console.error(`[MiniClaw] Failed to chmod script: ${e}`); }
+    }
+
+    // Pass arguments as a serialized JSON string to avoid shell escaping.
+    execArgs.push(JSON.stringify(args));
+
+    try {
+        const { stdout, stderr } = await execFileAsync(executable, execArgs, {
+            cwd: realSkillDir,
+            timeout: 30000,
+            maxBuffer: 1024 * 1024
+        });
+        return stdout || stderr;
+    } catch (e: any) {
+        return `Skill execution failed: ${e.message}\nOutput: ${e.stdout || e.stderr}`;
+    }
+}
+
 // === Content Hash State ===
 export interface ContentHashes {
     [sectionName: string]: string;
@@ -1176,46 +1220,7 @@ export class ContextKernel {
             return `Error: Script '${scriptFile}' not found.`;
         }
 
-        let realSkillDir: string;
-        let realScriptPath: string;
-        try {
-            [realSkillDir, realScriptPath] = await Promise.all([
-                fs.realpath(skillDir),
-                fs.realpath(scriptPath),
-            ]);
-            if (!isPathInside(realSkillDir, realScriptPath)) {
-                return "Security violation: script path escapes skill directory";
-            }
-        } catch {
-            return `Error: Script '${scriptFile}' not found.`;
-        }
-
-        // 2. Prepare execution
-        let executable = realScriptPath;
-        let execArgs: string[] = [];
-        if (realScriptPath.endsWith('.js')) {
-            executable = process.execPath;
-            execArgs = [realScriptPath];
-        } else {
-            // Try making it executable
-            try { await fs.chmod(realScriptPath, '755'); } catch (e) { console.error(`[MiniClaw] Failed to chmod script: ${e}`); }
-        }
-
-        // Pass arguments as a serialized JSON string to avoid shell escaping.
-        const argsStr = JSON.stringify(args);
-        execArgs.push(argsStr);
-
-        // 3. Execute
-        try {
-            const { stdout, stderr } = await execFileAsync(executable, execArgs, {
-                cwd: realSkillDir,
-                timeout: 30000,
-                maxBuffer: 1024 * 1024
-            });
-            return stdout || stderr;
-        } catch (e: any) {
-            return `Skill execution failed: ${e.message}\nOutput: ${e.stdout || e.stderr}`;
-        }
+        return executeResolvedSkillScript(skillDir, scriptPath, args);
     }
 
     // === SANDBOX VALIDATION ===

--- a/tests/skill-path.test.ts
+++ b/tests/skill-path.test.ts
@@ -1,7 +1,18 @@
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
-import { ContextKernel, resolveSkillDirPath, resolveSkillScriptPath } from "../src/kernel.js";
+import { access, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { afterEach, describe, expect, it } from "vitest";
+import { ContextKernel, executeResolvedSkillScript, resolveSkillDirPath, resolveSkillScriptPath } from "../src/kernel.js";
+
+const cleanupPaths: string[] = [];
+
+async function exists(filePath: string): Promise<boolean> {
+    return access(filePath).then(() => true, () => false);
+}
+
+afterEach(async () => {
+    await Promise.all(cleanupPaths.splice(0).map(p => rm(p, { recursive: true, force: true })));
+});
 
 describe("Skill script path resolution", () => {
     it("allows scripts inside a skill directory", () => {
@@ -37,5 +48,41 @@ describe("Skill script path resolution", () => {
 
         await expect(kernel.executeSkillScript("../../../../etc", "passwd", {}))
             .resolves.toContain("Security violation");
+    });
+
+    it("passes skill args without shell expansion", async () => {
+        const skillsRoot = await mkdtemp(path.join(os.tmpdir(), "miniclaw-skills-"));
+        cleanupPaths.push(skillsRoot);
+        const skillDir = path.join(skillsRoot, "issue6");
+        await mkdir(skillDir);
+
+        const argFile = path.join(os.tmpdir(), `miniclaw-arg-${Date.now()}.json`);
+        const marker = path.join(os.tmpdir(), `miniclaw-injection-${Date.now()}`);
+        cleanupPaths.push(argFile, marker);
+
+        const script = [
+            "import { writeFileSync } from 'node:fs';",
+            "writeFileSync(process.env.MINICLAW_TEST_ARG_FILE, process.argv[2] || '');",
+            "console.log('ok');",
+            "",
+        ].join("\n");
+        await writeFile(path.join(skillDir, "run.js"), script, "utf-8");
+
+        const originalArgFile = process.env.MINICLAW_TEST_ARG_FILE;
+        process.env.MINICLAW_TEST_ARG_FILE = argFile;
+        try {
+            const payload = `'; touch ${marker}; echo '`;
+            await expect(executeResolvedSkillScript(skillDir, path.join(skillDir, "run.js"), { payload }))
+                .resolves.toContain("ok");
+
+            expect(await exists(marker)).toBe(false);
+            expect(JSON.parse(await readFile(argFile, "utf-8"))).toEqual({ payload });
+        } finally {
+            if (originalArgFile === undefined) {
+                delete process.env.MINICLAW_TEST_ARG_FILE;
+            } else {
+                process.env.MINICLAW_TEST_ARG_FILE = originalArgFile;
+            }
+        }
     });
 });


### PR DESCRIPTION
## Summary
- Extract resolved skill-script execution into a reusable helper that keeps execFile-based execution centralized.
- Add a regression test for the reported skill args payload (`'; touch ...; echo '`) to verify it is passed as JSON argv text and never shell-expanded.

Fixes #6.

## Verification
- npm test
- npm run build